### PR TITLE
アプリケーションの認証方法をOAuth2.0に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
 .env
 venv
-my_google/credentials.json
 ditection_data
+my_google/credentials.json
+my_google/service_acount_credentials.json
+my_google/client_secret_id_path.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ __pycache__
 .env
 venv
 ditection_data
-my_google/credentials.json
-my_google/service_acount_credentials.json
+my_google/token.json
 my_google/client_secret_id_path.json

--- a/main.py
+++ b/main.py
@@ -1,5 +1,3 @@
-from dataclasses import field
-from select import select
 from my_google.auth import Auth
 from my_google.my_drive.module import *
 from googleapiclient.errors import HttpError as HttpError
@@ -10,8 +8,9 @@ import os
 def main(date, download_flag, delete_flag):
     #グーグルサービスクライアント初期化
     SCOPES = [os.getenv('SCOPE')]
-    GOOGLE_SECRET_PATH = os.getenv('GOOGLE_SECRET_PATH')
-    drive = Auth(SCOPES, GOOGLE_SECRET_PATH, 'drive', 'v3')
+    OAUTH_SECRET_PATH = os.getenv('OAUTH_SECRET_PATH')
+    CLIENT_SECRET_ID_PATH = os.getenv('CLIENT_SECRET_ID_PATH')
+    drive = Auth(SCOPES, OAUTH_SECRET_PATH, CLIENT_SECRET_ID_PATH, 'drive', 'v3')
 
     if(download_flag):
         download_ditection_data(drive, str(date))

--- a/my_google/auth.py
+++ b/my_google/auth.py
@@ -7,8 +7,6 @@ import os
 class Auth:
     def __init__(self, scope, secret_path, client_secret_id_path, service, version):
         credentials = self.OAuth(scope, secret_path, client_secret_id_path)
-        #sarvice_acount_credentials = service_account.Credentials.from_service_account_file(secret_path)
-        #scoped_creds = sarvice_acount_credentials.with_scopes(scope)
         self.client = build(service, version, credentials=credentials)
     
     def OAuth(self, scope, secret_path, client_secret_id_path):

--- a/my_google/auth.py
+++ b/my_google/auth.py
@@ -1,9 +1,33 @@
 from googleapiclient.discovery import build
-from google.oauth2 import service_account
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+import os
 
 class Auth:
-    def __init__(self, scope, secret_path, service, version):
-        sarvice_acount_credentials = service_account.Credentials.from_service_account_file(secret_path)
-        scoped_creds = sarvice_acount_credentials.with_scopes(scope)
-        self.client = build(service, version, credentials=scoped_creds)
+    def __init__(self, scope, secret_path, client_secret_id_path, service, version):
+        credentials = self.OAuth(scope, secret_path, client_secret_id_path)
+        #sarvice_acount_credentials = service_account.Credentials.from_service_account_file(secret_path)
+        #scoped_creds = sarvice_acount_credentials.with_scopes(scope)
+        self.client = build(service, version, credentials=credentials)
+    
+    def OAuth(self, scope, secret_path, client_secret_id_path):
+        credentials = None
+
+        if os.path.exists(secret_path):
+            credentials = Credentials.from_authorized_user_file(secret_path, scope)
+
+        if not credentials or not credentials.valid:
+            if credentials and credentials.expired and credentials.refresh_token:
+                credentials.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    client_secret_id_path, scope)
+                credentials = flow.run_local_server(port=0)
+
+            with open(secret_path, 'w') as token:
+                token.write(credentials.to_json())
+        
+        return credentials
+
 


### PR DESCRIPTION
# サービスアカウント
Aさんがサービスアカウントにドライブを共有すると、Aさんのドライブとは違うコピーした別のドライブとしてサービスアカウントが操作する。つまり、参照はできるが変更はAさんのドライブには反映されないっぽい。Aさんが所有者であったり、作成者であるファイルについてはサービスアカウントからの削除機能とか作れない。
[サービスアカウントの特性](https://zenn.dev/hankei6km/articles/owner-of-file-that-is-uploaded-by-service-account)

# 対策
よって、OAuth2.0認証でユーザごとに認証してそのユーザのドライブに対してAPI操作を行うことにする。
[OAuth2.0の認証設定について](https://developers.google.com/drive/api/quickstart/python)
desktopアプリを選択すれば、コールバックするためのURLの入力なくすんなりOAuth2.0認証のために必要な`client_secret`と`client_id`のjsonファイル取得できた。