### PR TITLE
Google Driveの特定のフォルダのファイルの削除機能追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,25 +12,53 @@ def main(date, download_flag, delete_flag):
     CLIENT_SECRET_ID_PATH = os.getenv('CLIENT_SECRET_ID_PATH')
     drive = Auth(SCOPES, OAUTH_SECRET_PATH, CLIENT_SECRET_ID_PATH, 'drive', 'v3')
 
-    if(download_flag):
-        download_ditection_data(drive, str(date))
+    keyword = 'logicIndexData'
 
-def download_ditection_data(drive, date):
+    if(download_flag):
+        download_ditection_data(drive, str(date), keyword)
+
+    if(delete_flag):
+        delete_ditection_data(drive, str(date))
+
+#Google Driveの特定のフォルダのファイルの取得
+def download_ditection_data(drive, date, keyword):
+    folder_id = os.getenv('FOLDER_ID')
     condition_list = [
+        f"'{folder_id}' in parents",
         f"fullText contains '{date}'",
-        "fullText contains 'logicIndexData'"
+        f"fullText contains '{keyword}'"
     ]
     condition = " and ".join(condition_list)
     fields = "nextPageToken, files(id, name)"
 
     files = search_file(drive, condition, fields)
 
-    for file in files:
-        splited_name = file['name'].split('_')
-        date_time = splited_name[0]
-        download_file_path = f"ditection_data/{date_time}_logicIndexData.csv"
+    if files:
+        for file in files:
+            splited_name = file['name'].split('_')
+            date_time = splited_name[0]
+            download_file_path = f"ditection_data/{date_time}_logicIndexData.csv"
 
-        download_file(drive, file['id'], download_file_path)
+            download_file(drive, file['id'], download_file_path)
+
+#Google Driveの特定のフォルダのファイルの削除
+def delete_ditection_data(drive, date):
+    folder_id = os.getenv('FOLDER_ID')
+    condition_list = [
+        f"'{folder_id}' in parents",
+        f"fullText contains '{date}'",
+    ]
+    condition = " and ".join(condition_list)
+    fields = "nextPageToken, files(id, name)"
+
+    files = search_file(drive, condition, fields)
+
+    if files:
+        for file in files:
+            delete_file(drive, file['id'])
+        
+        print(f'{date}についての{len(files)}個のファイルの削除が完了しました。')
+
 
 #TODO: ドライブ内の特定のファイルのダウンロードオプションとデリートオプションを設ける
 def set_args():

--- a/main.py
+++ b/main.py
@@ -22,16 +22,9 @@ def main(date, download_flag, delete_flag):
 
 #Google Driveの特定のフォルダのファイルの取得
 def download_ditection_data(drive, date, keyword):
-    folder_id = os.getenv('FOLDER_ID')
-    condition_list = [
-        f"'{folder_id}' in parents",
-        f"fullText contains '{date}'",
-        f"fullText contains '{keyword}'"
-    ]
-    condition = " and ".join(condition_list)
-    fields = "nextPageToken, files(id, name)"
+    params = search_file_ready(date, keyword)
 
-    files = search_file(drive, condition, fields)
+    files = search_file(drive, params['condition'], params['fields'])
 
     if files:
         for file in files:
@@ -43,15 +36,8 @@ def download_ditection_data(drive, date, keyword):
 
 #Google Driveの特定のフォルダのファイルの削除
 def delete_ditection_data(drive, date):
-    folder_id = os.getenv('FOLDER_ID')
-    condition_list = [
-        f"'{folder_id}' in parents",
-        f"fullText contains '{date}'",
-    ]
-    condition = " and ".join(condition_list)
-    fields = "nextPageToken, files(id, name)"
-
-    files = search_file(drive, condition, fields)
+    params = search_file_ready(date, all_flag=True)
+    files = search_file(drive, params['condition'], params['fields'])
 
     if files:
         for file in files:
@@ -59,6 +45,20 @@ def delete_ditection_data(drive, date):
         
         print(f'{date}についての{len(files)}個のファイルの削除が完了しました。')
 
+def search_file_ready(date, keyword=None, all_flag=False):
+    folder_id = os.getenv('FOLDER_ID')
+    condition_list = [
+        f"'{folder_id}' in parents",
+        f"fullText contains '{date}'",
+        f"fullText contains '{keyword}'"
+    ]
+    if all_flag:
+        condition_list.pop()
+        
+    condition = " and ".join(condition_list)
+    fields = "nextPageToken, files(id, name)"
+    
+    return {'condition': condition, 'fields': fields}
 
 #TODO: ドライブ内の特定のファイルのダウンロードオプションとデリートオプションを設ける
 def set_args():

--- a/my_google/my_drive/module.py
+++ b/my_google/my_drive/module.py
@@ -29,8 +29,7 @@ def search_file(drive, condition, fields):
 
             if next_page_token is None:
                 break
-        print(files)
-
+            
         return files
 
     except HttpError as error:

--- a/my_google/my_drive/module.py
+++ b/my_google/my_drive/module.py
@@ -1,4 +1,5 @@
 from array import array
+from urllib import request
 from googleapiclient.errors import HttpError as HttpError
 from googleapiclient.http import MediaIoBaseDownload
 
@@ -7,26 +8,29 @@ def search_file(drive, condition, fields):
         files = []
         next_page_token = None
         page_size = 100
-        limit_count = 0
+        request_count = 0
 
         while True:
-            limit_count += 1
             result = drive.client.files().list(
                 q=condition,
                 fields=fields,
                 pageSize=page_size,
-                pageToken=next_page_token
+                pageToken=next_page_token,
             ).execute()
+            request_count += 1
 
-            next_page_token = result.get('nextPageToken', None)
-            if next_page_token is None:
-                break            
-            if limit_count == 10:
+            next_page_token = result.get('nextPageToken', None)            
+            if request_count == 10:
                 print(f'過剰なリクエストです。時間を置いて再度リクエストしてください。')
             
-            print(f'最低リクエスト数: {limit_count * page_size}')
+            print(f'最低リクエスト数: {request_count}')
             
             files.extend(result.get('files', []))
+
+            if next_page_token is None:
+                break
+        print(files)
+
         return files
 
     except HttpError as error:
@@ -48,3 +52,10 @@ def download_file(drive, file_id, download_file_path):
         print(f'An error occurred: {error}')
     except Exception as e:
         print(f'[ERROR] {type(e)}: {str(e)}')
+
+
+def delete_file(drive, file_id):
+    try:
+        drive.client.files().delete(fileId=file_id).execute()
+    except Exception as e:
+        print(f'[ERROR] {type(e): str(e)}')


### PR DESCRIPTION
# 概要
コマンドライン引数(`-d`のこと)を使って、削除を求められたら実行される関数を作った。難しかったのは、サービスアカウントで操作する`Google Drive`の挙動。詳しくは[こちら](https://github.com/haruya3/graduate-project/pull/3)参考に。
# はまったところ
## 共有ドライブ
**また、特定ファイルの指定の仕方も難しかった。今回操作するドライブが共有ドライブということで、普通のドライブとは違った`q`の指定があるのかなとか[色々](https://zenn.dev/sa2knight/scraps/65df31ec87bbfd)調べてしまった。結局、そんなことなく普通のドライブと一緒だった。
## `list()`の引数たち
`list()`で`mimeType`という引数がある。これには、ドライブ内のファイルかフォルダかの指定もできる。[公式ドキュメント](https://developers.google.com/drive/api/guides/mime-types)。
よって、フォルダ探す際はこれを指定することで`Google`に負担をかけずに済む。また、`q`でも以下のような指定ができる。
```python
q=f"{folder_id} in parents"
```
これによって、その指定したフォルダ内から検索条件に合うもの(ファイルやフォルダか、、)を探してくれる。つまり、処理速度も負荷も小さくなるのでつけること。