### PR TITLE
Google Driveから取得したデータでグラフを作成するための準備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ __pycache__
 .env
 venv
 ditection_data
+fatigue_data
 my_google/token.json
 my_google/client_secret_id_path.json

--- a/fatigue.py
+++ b/fatigue.py
@@ -1,0 +1,44 @@
+import datetime, os, time
+from tkinter import messagebox
+
+def main():
+    start_time = datetime.datetime.now()
+    while True:
+        now_time = datetime.datetime.now()
+        pass_time = now_time.minute - start_time.minute
+    
+        if pass_time != 0 and pass_time % 1 == 0:
+            messagebox.showinfo('入力通知','1分以内に被験者の疲労度を入力してください')
+            #TODO:入力のバリデーションしてないから余裕あればやる
+            fatigue = input("被験者の疲労度を入力してください(終了するにはexitと打ってください)\n")
+
+            if fatigue == 'exit':
+                print("終了します")
+                exit()
+            file_path = get_file_path(now_time)
+            
+            check_exist_and_may_create(file_path)
+            
+            with open(file_path, 'w') as file:
+                file.write(fatigue)
+            
+            time.sleep(60)
+
+def get_file_path(pass_time):
+    year = pass_time.year
+    month = pass_time.month
+    day = pass_time.day
+    hour = pass_time.hour
+    minute = pass_time.minute
+    return f'./fatigue_data/{year}/{month}/{day}/{hour}/{minute}.txt'
+
+#TODO:main.pyでも使っているのでmodule化したい
+""" あるパスの存在確認をする。存在しない場合は作成する"""
+def check_exist_and_may_create(path):
+    directory_path = os.path.dirname(path)
+
+    if not os.path.exists(directory_path):
+        os.makedirs(directory_path)
+    
+if __name__ == '__main__':
+    main()

--- a/fatigue.py
+++ b/fatigue.py
@@ -7,7 +7,7 @@ def main():
         now_time = datetime.datetime.now()
         pass_time = now_time.minute - start_time.minute
     
-        if pass_time != 0 and pass_time % 1 == 0:
+        if pass_time != 0 and pass_time % 5 == 0:
             messagebox.showinfo('入力通知','1分以内に被験者の疲労度を入力してください')
             #TODO:入力のバリデーションしてないから余裕あればやる
             fatigue = input("被験者の疲労度を入力してください(終了するにはexitと打ってください)\n")

--- a/graph/module.py
+++ b/graph/module.py
@@ -7,7 +7,7 @@ def create_graph_from_ditection_data_ready(date, hours):
     month = date[4:6]
     day = date[6:8]
 
-    #(例)[[X1(VDT作業開始からの経過時間(5分ごと)) Y1(瞬目の間隔時間平均(5分ごと)) Z1(疲労度申告(5分ごと))], [X2 Y2 Z1],...[Xn Yn Zn]]
+    #(例)[[X1(VDT作業開始からの経過時間(5分ごと)) Y1(瞬目の間隔時間平均(5分ごと)) Z1(疲労度申告(5分ごと))], [X2 Y2 Z1],...[Xn Yn Zn]], 全てint型。
     date_blink_interval_time_fatigue_data = []
     #疲労度
     fatigue = 0
@@ -41,21 +41,21 @@ def create_graph_from_ditection_data_ready(date, hours):
             for index, per_minitue_data in enumerate(date_blink_interval_time_per_hour_data):
                 blink_interval_time_average = 0
                 blink_interval_time_sum = 0
+                minute = per_minitue_data[0][0][14:16]
+                fatigue_data_file_path = f'./fatigue_data/{year}/{month}/{day}/{hour}/{minute}.txt'
+
+                #経過時間の取得
+                pass_time = int(minute) - start_vdt_minitue
 
                 #5分ごとに疲労度のデータ取得
-                if index % 4 == 0:
-                    #疲労度は./fatigue_data/{year}/{month}/{day}/{hour}/{minute}.txtにあるので、
-                    #ファイルパスで指定してその時に対応する疲労度を取得する
-                    fatigue = 3
+                if pass_time % 5 == 0 and os.path.exists(fatigue_data_file_path):
+                    fatigue = get_fatigue_data(fatigue_data_file_path)
 
                 #1分ごとの瞬目の時間間隔のデータの取得
                 for data in per_minitue_data:
                     blink_interval_time_sum += data[1]
 
                 blink_interval_time_average = int(blink_interval_time_sum / len(per_minitue_data))
-
-                #経過時間の取得
-                pass_time = int(data[0][14:16]) - start_vdt_minitue
 
                 #1分ごとの経過時間・瞬目の間隔時間平均・疲労度のレコードを作成
                 date_blink_interval_time_fatigue_data.append([pass_time, blink_interval_time_average, fatigue])
@@ -65,3 +65,9 @@ def create_graph_from_ditection_data_ready(date, hours):
             continue
 
     return date_blink_interval_time_fatigue_data 
+
+""" 疲労度の値を取得 """
+def get_fatigue_data(file_path):
+    with open(file_path, 'r') as file:
+        value = file.read()
+    return int(value)

--- a/graph/module.py
+++ b/graph/module.py
@@ -1,0 +1,67 @@
+import glob, os
+import pandas as pd
+
+#download_ditection_dataで取得したデータからグラフを作成するための準備
+def create_graph_from_ditection_data_ready(date, hours):
+    year = date[0:4]
+    month = date[4:6]
+    day = date[6:8]
+
+    #(例)[[X1(VDT作業開始からの経過時間(5分ごと)) Y1(瞬目の間隔時間平均(5分ごと)) Z1(疲労度申告(5分ごと))], [X2 Y2 Z1],...[Xn Yn Zn]]
+    date_blink_interval_time_fatigue_data = []
+    #疲労度
+    fatigue = 0
+    #VDT作業開始時間
+    start_vdt_minitue = 0
+    
+    #1時間ごとにデータ(date_blink_interval_time_fatigue_data)を取得していく->hours[-1]とすることで配列要素1つだけの時エラー回避
+    for hour in range(hours[0], hours[-1] + 1):
+        pathes = glob.glob(f'./ditection_data/{year}/{month}/{day}/{hour}/*')
+        date_blink_interval_time_per_hour_data = []
+
+        if pathes:
+            for path in pathes:
+                #空ファイルは無視する
+                if os.path.getsize(path) != 0:
+                    #デフォルトで、delimiterが,になっている
+                    csv_data = pd.read_csv(path, usecols=['date', 'blinkIntervalMean'], )
+                    date_blink_interval_time_per_hour_data.append(csv_data.values)
+        else:
+            print("指定したファイルは存在しません。恐らく時間指定を間違っているかそのようなファイルパスは存在しません。")
+            
+        # 一つの配列はcsvファイルでいう一つの行レコードとなる。
+        date_blink_interval_time_fatigue_data = []
+        
+        if date_blink_interval_time_per_hour_data:
+            #まだVDT作業開始時間を設定していない場合
+            if start_vdt_minitue == 0:
+                start_vdt_minitue = int(date_blink_interval_time_per_hour_data[0][0][0][14:16])
+
+            #VDT作業開始時間
+            for index, per_minitue_data in enumerate(date_blink_interval_time_per_hour_data):
+                blink_interval_time_average = 0
+                blink_interval_time_sum = 0
+
+                #5分ごとに疲労度のデータ取得
+                if index % 4 == 0:
+                    #疲労度は./fatigue_data/{year}/{month}/{day}/{hour}/{minute}.txtにあるので、
+                    #ファイルパスで指定してその時に対応する疲労度を取得する
+                    fatigue = 3
+
+                #1分ごとの瞬目の時間間隔のデータの取得
+                for data in per_minitue_data:
+                    blink_interval_time_sum += data[1]
+
+                blink_interval_time_average = int(blink_interval_time_sum / len(per_minitue_data))
+
+                #経過時間の取得
+                pass_time = int(data[0][14:16]) - start_vdt_minitue
+
+                #1分ごとの経過時間・瞬目の間隔時間平均・疲労度のレコードを作成
+                date_blink_interval_time_fatigue_data.append([pass_time, blink_interval_time_average, fatigue])
+        
+        #もし該当する時間にデータが取得されていなかったらスキップする
+        else:
+            continue
+
+    return date_blink_interval_time_fatigue_data 

--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ def create_graph_from_ditection_data(date):
     hours = list(map(lambda x: int(x), input("時間範囲を指定してください(例)12時から15時なら12-15, 1時なら01とする\n").split('-')))
     result = create_graph_from_ditection_data_ready(date, hours)
     print(result)
+    #df = pd.DataFrame() グラフ作成のためのオブジェクト作成
 
 """ Google Drive APIで特定ファイル検索する際の条件(q, fieldsなど)に指定する値の準備 """
 def search_file_ready(date, keyword=None, all_flag=False):

--- a/main.py
+++ b/main.py
@@ -1,12 +1,10 @@
-from datetime import datetime
-from venv import create
 from my_google.auth import Auth
 from my_google.my_drive.module import *
 from googleapiclient.errors import HttpError as HttpError
+from graph.module import *
 from dotenv import load_dotenv
 load_dotenv()
-import os, glob
-import pandas as pd
+import os
 
 def main(date, download_flag, delete_flag, create_flag):
     #グーグルサービスクライアント初期化
@@ -26,7 +24,7 @@ def main(date, download_flag, delete_flag, create_flag):
     if(create_flag):
         create_graph_from_ditection_data(str(date))
 
-#Google Driveの特定のフォルダのファイルの取得
+""" Google Driveの特定のフォルダのファイルの取得 """
 def download_ditection_data(drive, date, keyword):
     params = search_file_ready(date, keyword)
 
@@ -42,7 +40,7 @@ def download_ditection_data(drive, date, keyword):
     else:
         print("指定した条件に一致するファイルは見つかりませんでいた。")
 
-#Google Driveの特定のフォルダのファイルの削除
+""" Google Driveの特定のフォルダのファイルの削除 """
 def delete_ditection_data(drive, date):
     params = search_file_ready(date, all_flag=True)
     files = search_file(drive, params['condition'], params['fields'])
@@ -54,12 +52,13 @@ def delete_ditection_data(drive, date):
         print(f'{date}についての{len(files)}個のファイルの削除が完了しました。')
 
 
+""" Jins memeのデータでグラフ作成 """
 def create_graph_from_ditection_data(date):
     hours = list(map(lambda x: int(x), input("時間範囲を指定してください(例)12時から15時なら12-15, 1時なら01とする\n").split('-')))
     result = create_graph_from_ditection_data_ready(date, hours)
     print(result)
 
-#Google Drive APIで特定ファイル検索する際の条件(q, fieldsなど)に指定する値の準備
+""" Google Drive APIで特定ファイル検索する際の条件(q, fieldsなど)に指定する値の準備 """
 def search_file_ready(date, keyword=None, all_flag=False):
     folder_id = os.getenv('FOLDER_ID')
     condition_list = [
@@ -74,70 +73,6 @@ def search_file_ready(date, keyword=None, all_flag=False):
     fields = "nextPageToken, files(id, name)"
     
     return {'condition': condition, 'fields': fields}
-
-#download_ditection_dataで取得したデータからグラフを作成するための準備
-def create_graph_from_ditection_data_ready(date, hours):
-    year = date[0:4]
-    month = date[4:6]
-    day = date[6:8]
-
-    #(例)[[X1(VDT作業開始からの経過時間(5分ごと)) Y1(瞬目の間隔時間平均(5分ごと)) Z1(疲労度申告(5分ごと))], [X2 Y2 Z1],...[Xn Yn Zn]]
-    date_blink_interval_time_fatigue_data = []
-    #疲労度
-    fatigue = 0
-    #VDT作業開始時間
-    start_vdt_minitue = 0
-    
-    #1時間ごとにデータ(date_blink_interval_time_fatigue_data)を取得していく->hours[-1]とすることで配列要素1つだけの時エラー回避
-    for hour in range(hours[0], hours[-1] + 1):
-        #12-15で12から15時の間のデータのグラフを作るという意味にして、rangeでrang(12, 15)でhourをfor分で回せば、できそう？
-        pathes = glob.glob(f'./ditection_data/{year}/{month}/{day}/{hour}/*')
-        date_blink_interval_time_per_hour_data = []
-
-        if pathes:
-            for path in pathes:
-                #空ファイルは無視する
-                if os.path.getsize(path) != 0:
-                    #デフォルトで、delimiterが,になっている
-                    csv_data = pd.read_csv(path, usecols=['date', 'blinkIntervalMean'], )
-                    date_blink_interval_time_per_hour_data.append(csv_data.values)
-        else:
-            print("指定したファイルは存在しません。恐らく時間指定を間違っているかそのようなファイルパスは存在しません。")
-            
-        # 一つの配列はcsvファイルでいう一つの行レコードとなる。
-        date_blink_interval_time_fatigue_data = []
-        
-        if date_blink_interval_time_per_hour_data:
-            #まだVDT作業開始時間を設定していない場合
-            if start_vdt_minitue == 0:
-                start_vdt_minitue = int(date_blink_interval_time_per_hour_data[0][0][0][14:16])
-
-            #VDT作業開始時間
-            for index, per_minitue_data in enumerate(date_blink_interval_time_per_hour_data):
-                blink_interval_time_average = 0
-                blink_interval_time_sum = 0
-
-                #5分ごとに疲労度のデータ取得
-                if index % 4 == 0:
-                    fatigue = 3
-
-                #1分ごとの瞬目の時間間隔のデータの取得
-                for data in per_minitue_data:
-                    blink_interval_time_sum += data[1]
-
-                blink_interval_time_average = int(blink_interval_time_sum / len(per_minitue_data))
-
-                #経過時間の取得
-                pass_time = int(data[0][14:16]) - start_vdt_minitue
-
-                #1分ごとの経過時間・瞬目の間隔時間平均・疲労度のレコードを作成
-                date_blink_interval_time_fatigue_data.append([pass_time, blink_interval_time_average, fatigue])
-        
-        #もし該当する時間にデータが取得されていなかったらスキップする
-        else:
-            continue
-
-    return date_blink_interval_time_fatigue_data 
     
 """ Google Drive APIでファイルをダウンロードするさいに必要なファイルパスを取得する """
 def get_download_file_path(file):

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
+from datetime import datetime
 from venv import create
 from my_google.auth import Auth
 from my_google.my_drive.module import *
 from googleapiclient.errors import HttpError as HttpError
 from dotenv import load_dotenv
 load_dotenv()
-import os
+import os, glob
+import pandas as pd
 
 def main(date, download_flag, delete_flag, create_flag):
     #グーグルサービスクライアント初期化
@@ -22,7 +24,7 @@ def main(date, download_flag, delete_flag, create_flag):
         delete_ditection_data(drive, str(date))
 
     if(create_flag):
-        create_graph_from_ditection_data_ready()
+        create_graph_from_ditection_data(str(date))
 
 #Google Driveの特定のフォルダのファイルの取得
 def download_ditection_data(drive, date, keyword):
@@ -32,11 +34,13 @@ def download_ditection_data(drive, date, keyword):
 
     if files:
         for file in files:
-            splited_name = file['name'].split('_')
-            date_time = splited_name[0]
-            download_file_path = f"ditection_data/{date_time}_logicIndexData.csv"
+            download_file_path = get_download_file_path(file)
+
+            check_exist_and_may_create(download_file_path)
 
             download_file(drive, file['id'], download_file_path)
+    else:
+        print("指定した条件に一致するファイルは見つかりませんでいた。")
 
 #Google Driveの特定のフォルダのファイルの削除
 def delete_ditection_data(drive, date):
@@ -49,10 +53,13 @@ def delete_ditection_data(drive, date):
         
         print(f'{date}についての{len(files)}個のファイルの削除が完了しました。')
 
-#download_ditection_dataで取得したデータからグラフを作成するための準備
-def create_graph_from_ditection_data_ready():
-    print("成功")
 
+def create_graph_from_ditection_data(date):
+    hours = list(map(lambda x: int(x), input("時間範囲を指定してください(例)12時から15時なら12-15, 1時なら01とする\n").split('-')))
+    result = create_graph_from_ditection_data_ready(date, hours)
+    print(result)
+
+#Google Drive APIで特定ファイル検索する際の条件(q, fieldsなど)に指定する値の準備
 def search_file_ready(date, keyword=None, all_flag=False):
     folder_id = os.getenv('FOLDER_ID')
     condition_list = [
@@ -67,6 +74,91 @@ def search_file_ready(date, keyword=None, all_flag=False):
     fields = "nextPageToken, files(id, name)"
     
     return {'condition': condition, 'fields': fields}
+
+#download_ditection_dataで取得したデータからグラフを作成するための準備
+def create_graph_from_ditection_data_ready(date, hours):
+    year = date[0:4]
+    month = date[4:6]
+    day = date[6:8]
+
+    #(例)[[X1(VDT作業開始からの経過時間(5分ごと)) Y1(瞬目の間隔時間平均(5分ごと)) Z1(疲労度申告(5分ごと))], [X2 Y2 Z1],...[Xn Yn Zn]]
+    date_blink_interval_time_fatigue_data = []
+    #疲労度
+    fatigue = 0
+    #VDT作業開始時間
+    start_vdt_minitue = 0
+    
+    #1時間ごとにデータ(date_blink_interval_time_fatigue_data)を取得していく->hours[-1]とすることで配列要素1つだけの時エラー回避
+    for hour in range(hours[0], hours[-1] + 1):
+        #12-15で12から15時の間のデータのグラフを作るという意味にして、rangeでrang(12, 15)でhourをfor分で回せば、できそう？
+        pathes = glob.glob(f'./ditection_data/{year}/{month}/{day}/{hour}/*')
+        date_blink_interval_time_per_hour_data = []
+
+        if pathes:
+            for path in pathes:
+                #空ファイルは無視する
+                if os.path.getsize(path) != 0:
+                    #デフォルトで、delimiterが,になっている
+                    csv_data = pd.read_csv(path, usecols=['date', 'blinkIntervalMean'], )
+                    date_blink_interval_time_per_hour_data.append(csv_data.values)
+        else:
+            print("指定したファイルは存在しません。恐らく時間指定を間違っているかそのようなファイルパスは存在しません。")
+            
+        # 一つの配列はcsvファイルでいう一つの行レコードとなる。
+        date_blink_interval_time_fatigue_data = []
+        
+        if date_blink_interval_time_per_hour_data:
+            #まだVDT作業開始時間を設定していない場合
+            if start_vdt_minitue == 0:
+                start_vdt_minitue = int(date_blink_interval_time_per_hour_data[0][0][0][14:16])
+
+            #VDT作業開始時間
+            for index, per_minitue_data in enumerate(date_blink_interval_time_per_hour_data):
+                blink_interval_time_average = 0
+                blink_interval_time_sum = 0
+
+                #5分ごとに疲労度のデータ取得
+                if index % 4 == 0:
+                    fatigue = 3
+
+                #1分ごとの瞬目の時間間隔のデータの取得
+                for data in per_minitue_data:
+                    blink_interval_time_sum += data[1]
+
+                blink_interval_time_average = int(blink_interval_time_sum / len(per_minitue_data))
+
+                #経過時間の取得
+                pass_time = int(data[0][14:16]) - start_vdt_minitue
+
+                #1分ごとの経過時間・瞬目の間隔時間平均・疲労度のレコードを作成
+                date_blink_interval_time_fatigue_data.append([pass_time, blink_interval_time_average, fatigue])
+        
+        #もし該当する時間にデータが取得されていなかったらスキップする
+        else:
+            continue
+
+    return date_blink_interval_time_fatigue_data 
+    
+""" Google Drive APIでファイルをダウンロードするさいに必要なファイルパスを取得する """
+def get_download_file_path(file):
+    splited_name = file['name'].split('_')
+    date_time = splited_name[0].split('-')
+    year = date_time[0][0:4]
+    month = date_time[0][4:6]
+    day = date_time[0][6:8]
+    hour = date_time[1][0:2]
+    minitue = date_time[1][2:4]
+    second = date_time[1][4:6]
+
+    return  f"ditection_data/{year}/{month}/{day}/{hour}/{minitue}-{second}_logicIndexData.csv"
+
+""" あるパスの存在確認をする。存在しない場合は作成する"""
+def check_exist_and_may_create(path):
+    directory_path = os.path.dirname(path)
+
+    if not os.path.exists(directory_path):
+        os.makedirs(directory_path)
+    
 
 #TODO: ドライブ内の特定のファイルのダウンロードオプションとデリートオプションを設ける
 def set_args():

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from venv import create
 from my_google.auth import Auth
 from my_google.my_drive.module import *
 from googleapiclient.errors import HttpError as HttpError
@@ -5,7 +6,7 @@ from dotenv import load_dotenv
 load_dotenv()
 import os
 
-def main(date, download_flag, delete_flag):
+def main(date, download_flag, delete_flag, create_flag):
     #グーグルサービスクライアント初期化
     SCOPES = [os.getenv('SCOPE')]
     OAUTH_SECRET_PATH = os.getenv('OAUTH_SECRET_PATH')
@@ -19,6 +20,9 @@ def main(date, download_flag, delete_flag):
 
     if(delete_flag):
         delete_ditection_data(drive, str(date))
+
+    if(create_flag):
+        create_graph_from_ditection_data_ready()
 
 #Google Driveの特定のフォルダのファイルの取得
 def download_ditection_data(drive, date, keyword):
@@ -45,6 +49,10 @@ def delete_ditection_data(drive, date):
         
         print(f'{date}についての{len(files)}個のファイルの削除が完了しました。')
 
+#download_ditection_dataで取得したデータからグラフを作成するための準備
+def create_graph_from_ditection_data_ready():
+    print("成功")
+
 def search_file_ready(date, keyword=None, all_flag=False):
     folder_id = os.getenv('FOLDER_ID')
     condition_list = [
@@ -65,8 +73,9 @@ def set_args():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("-w", "--when", help="いつのデータを取得するか指定する。形式: (yyyymmdd)", type=int, required=True)
-    parser.add_argument("-d", "--download", help="ダウンロード", action='store_true')
-    parser.add_argument("-D", "--delete", help="いつのデータを取得するか指定する", action='store_true')
+    parser.add_argument("-d", "--download", help="データを取得する", action='store_true')
+    parser.add_argument("-D", "--delete", help="データを削除する", action='store_true')
+    parser.add_argument("-c", "--create", help="取得したデータからグラフを作成する", action='store_true')
     return parser.parse_args()
 
 def check_google_drive_action(*actions):
@@ -81,6 +90,6 @@ def check_google_drive_action(*actions):
 
 if __name__ == '__main__':
     args = set_args()
-    check_google_drive_action(args.download, args.delete)
+    check_google_drive_action(args.download, args.delete, args.create)
 
-    main(args.when, args.download, args.delete)
+    main(args.when, args.download, args.delete, args.create)


### PR DESCRIPTION
# 概要
グラフを作成するために、以下の準備をする。
- `main.py`にグラフ作成するということを伝えるコマンドライン引数の追加
- 取得した`csv`ファイルから必要なデータ(`blinkIntervalMean`やVDT作業開始からの経過時間など)を取得
  - データの加工まで済ませる(5分間ごとの瞬目の間隔時間平均にするなど) 
  - このデータ取得や加工を時間単位で行いたい時用に、時間指定のコマンドライン引数も用意するか？
    - おそらく1日単位だとデータ量が多すぎて、グラフが分かりにくくなる可能性がある 

どのようなグラフが必要で、そのグラフを構成する要素は何なのか[詳しくはこの記事](https://level-up-geek.esa.io/posts/243#%E5%BF%85%E8%A6%81%E3%81%AA%E3%82%B0%E3%83%A9%E3%83%95)を参考に。

## 最終的に
`create_graph_from_ditection_data_ready`という関数で、1時間ごとに`[[X1(VDT作業開始からの経過時間) Y1(瞬目の間隔時間平均(1分ごと)) Z1(疲労度申告(5分ごと))], [X2 Y2 Z1],...[Xn Yn Zn]]`という形で、グラフに必要な1レコードを作成している。1日のうちのどの部分のグラフを作るか指定できるように、`input()`入力で**時間指定してグラフの作成ができるように準備段階を整えた**。
→これにより、ファイルパスでグラフを作りたい時間の指定をできるようになったため
→処理のネストが少し深くなってしまった(主に時間ごとにファイルパスが違うことから起因するfor文)

# 問題点
**VDT作業開始からの経過時間**と**瞬目の間隔時間平均**は、`JINS meme`で取得できるデータだが**被験者の疲労度**は自分で記録する必要がある。しかし、これらの値は相互に関係していてお互いのデータが結びつくようにする必要がある。

## 解決策
まず、被験者の疲労度を記録するためのpythonスクリプトとして`fatigue.py`を作成する。これで、実験中に`./fatigue_data/{year}/{month}/{day}/{hour}/{minute}.txt`に疲労度は書いていけるのでグラフ作成時は、**VDT作業開始からの経過時間**と**瞬目の間隔時間平均**のデータと**疲労度**のデータは各時間で紐づくことができた。**VDT作業開始からの経過時間**と**瞬目の間隔時間平均**のデータを扱っている時の時間で`graph.py`にてファイルパスを指定して疲労度を取得していく。