### PR TITLE
「休憩あり」のディレクトリを作成する

### DIFF
--- a/data_edit/module.py
+++ b/data_edit/module.py
@@ -6,18 +6,6 @@ def get_date(date):
     return year, month, day
 
 ###########疲労度について#############
-
-""" 疲労度のパスを取得 """
-def get_fatigue_data_path(date_time):
-    year = date_time[0:4]
-    month = date_time[5:7]
-    day = date_time[8:10]
-    hour_in_japan = str(int(date_time[11:13]) + 9).zfill(2)
-    minute = date_time[14:16]    
-    fatigue_data_path = f'./fatigue_data/{year}/{month}/{day}/{hour_in_japan}/{minute}.txt'
-    
-    return fatigue_data_path
-
 """ 疲労度の値を取得 """
 def get_fatigue_data(file_path):
     with open(file_path, 'r') as file:
@@ -48,11 +36,31 @@ def get_date_from_jins_meme_file(drive, files, jins_meme_data_name):
         exit()
 
 """ 疲労度を保存するファイルパスを取得 """
-def get_fatigue_file_path(date):
+def get_fatigue_file_path(date, rest_flag=False):
     year = date.year
     month = str(date.month).zfill(2)
     day = str(date.day).zfill(2)
     hour = str(date.hour).zfill(2)
     minute = str(date.minute).zfill(2)
+    file_path = f'./fatigue_data/{year}/{month}/{day}/{hour}/{minute}.txt'
 
-    return f'./fatigue_data/{year}/{month}/{day}/{hour}/{minute}.txt'
+    if rest_flag:
+        file_path = f'./fatigue_data/rest/{year}/{month}/{day}/{hour}/{minute}.txt'
+    
+    return file_path
+
+#TODO:これは、旧式。よって、上記のget_fatigue_file_path関数に置き換える必要がある。
+#そのためには、pass_timeの求め方もdatetime.timedeltaでやらないといけないかも
+""" 疲労度のパスを取得 """
+def get_fatigue_data_path_old(date_time, rest_flag=False):
+    year = date_time[0:4]
+    month = date_time[5:7]
+    day = date_time[8:10]
+    hour_in_japan = str(int(date_time[11:13]) + 9).zfill(2)
+    minute = date_time[14:16]    
+    fatigue_data_path = f'./fatigue_data/{year}/{month}/{day}/{hour_in_japan}/{minute}.txt'
+
+    if rest_flag:
+        fatigue_data_path = f'./fatigue_data/rest/{year}/{month}/{day}/{hour_in_japan}/{minute}.txt'
+    
+    return fatigue_data_path

--- a/data_edit/table/module.py
+++ b/data_edit/table/module.py
@@ -1,15 +1,15 @@
 import os, glob
 from statistics import mean
 from tabulate import tabulate
-from data_edit.module import get_date, get_fatigue_data_path, get_fatigue_data
+from data_edit.module import get_date, get_fatigue_data_path_old, get_fatigue_data
 from file_operation.module import readCsv
 from dotenv import load_dotenv
 load_dotenv()
 
 """ 疲労度ごとの瞬目の間隔時間平均の振り幅の表作成 """
-def create_blink_interval_time_amplitude_table(date, jins_meme_data_name):
+def create_blink_interval_time_amplitude_table(date, jins_meme_data_name, rest_flag):
     #疲労度ごとの瞬目の間隔時間平均値のhashを取得
-    blink_interval_at_fatigue_hash = ready_blink_interval_at_fatigue_hash(date, jins_meme_data_name)
+    blink_interval_at_fatigue_hash = ready_blink_interval_at_fatigue_hash(date, jins_meme_data_name, rest_flag=rest_flag)
     #取得したhashの分析
     blink_interval_at_fatigue_minimum_max, blink_interval_at_fatigue_average = analyze_blink_interval_at_fatigue(blink_interval_at_fatigue_hash)
     
@@ -30,9 +30,13 @@ def create_blink_interval_time_amplitude_table(date, jins_meme_data_name):
     return table_minimum_max, table_average
 
 """ 疲労度ごとの瞬目の間隔時間平均の関係を作成(dict形式) """
-def ready_blink_interval_at_fatigue_hash(date, jins_meme_data_name):
+def ready_blink_interval_at_fatigue_hash(date, jins_meme_data_name, rest_flag):
     year, month, _ = get_date(date)
     target_pathes = glob.glob(f'./ditection_data/{year}/*/*/*/*{jins_meme_data_name}.csv')
+    
+    if rest_flag:
+        target_pathes= glob.glob(f'./ditection_data/rest/{year}/*/*/*/*{jins_meme_data_name}.csv')
+
     colums = ['date', 'strongBlinkIntervalAvg']
     date_blink_interval_list = readCsv(target_pathes, colums)
     
@@ -43,7 +47,8 @@ def ready_blink_interval_at_fatigue_hash(date, jins_meme_data_name):
 
     for date_blink_interval in [value[0] for value in date_blink_interval_list]:
         if len(date_blink_interval) != 0:
-            fatigue_data_path = get_fatigue_data_path(date_blink_interval[0])
+            fatigue_data_path = get_fatigue_data_path_old(date_blink_interval[0], rest_flag=rest_flag)
+            #毎分ごとのdate_blink_intervalをfor文で回すため疲労度のファイルパスが存在する時は必ずある。
             if os.path.exists(fatigue_data_path):
                 fatigue = get_fatigue_data(fatigue_data_path)
                 #特殊なフィルター(不正なデータを取り除く)

--- a/fatigue.py
+++ b/fatigue.py
@@ -13,6 +13,8 @@ def main():
     CLIENT_SECRET_ID_PATH = os.getenv('CLIENT_SECRET_ID_PATH')
     drive = Auth(SCOPES, OAUTH_SECRET_PATH, CLIENT_SECRET_ID_PATH, 'drive', 'v3')
 
+    rest_flag = trance_boolean(input("「休憩あり」の実験ですか。(例)yes or no\n"))
+
     jins_meme_data_name = 'summaryData'
     date_time = check_date(input('日付を入力してください(例): 20221102 12:30\n'))
 
@@ -36,7 +38,7 @@ def main():
             files = execute_search_file(drive, date_for_search_file, jins_meme_data_name, page_limit=1)
             date_for_file_path = get_date_from_jins_meme_file(drive, files, jins_meme_data_name)
             
-            file_path = get_fatigue_file_path(date_for_file_path)
+            file_path = get_fatigue_file_path(date_for_file_path, rest_flag=rest_flag)
             check_exist_and_may_create(file_path)
 
             print("経過時間: ")
@@ -48,6 +50,16 @@ def main():
                 file.write(fatigue)
             
             time.sleep(60)
+
+""" 「休憩あり」かの標準入力をBoolean型に変換する(ついでに入力値の正常チェック) """
+def trance_boolean(str):
+    if str == 'yes':
+        return True
+    elif str == 'no':
+        return False
+    else:
+        print('yesかnoで答えてください。')
+        exit()
 
 """ 経過時間の取得 """
 def get_pass_time(start_time, now):

--- a/main.py
+++ b/main.py
@@ -37,13 +37,21 @@ def download_ditection_data_flow(drive, date, jins_meme_data_name):
     params = search_file_ready(date, jins_meme_data_name)
 
     files = search_file(drive, params['condition'], params['fields'])
+    rest_flag = trance_boolean(input("「休憩あり」の実験データとして取得しますか。(例)yes or no\n"))
+    specify_hour = input("何時データを取得するか指定しください。(例)10時から12時のデータ->10-12\n").split('-')
+    start_specify_hour = int(specify_hour[0])
+    end_specify_hour = int(specify_hour[-1])
 
     if files:
         for file in files:
-            download_file_path = get_download_file_path(file, jins_meme_data_name)
-
+            download_file_path = get_download_file_path(file, jins_meme_data_name, rest_flag)
+            hour = int(download_file_path[26:28])
             check_exist_and_may_create(download_file_path)
-
+            
+            if start_specify_hour > hour or hour > end_specify_hour:
+                print(download_file_path)
+                continue
+                
             download_file(drive, file['id'], download_file_path)
     else:
         print("指定した条件に一致するファイルは見つかりませんでいた。")
@@ -74,21 +82,36 @@ def create_graph_from_ditection_data_flow(date, jins_meme_data_name):
     fatigue_relation_value = os.getenv('FATIGUE_RELATION_VALUE')
     csv_colums = ['date', fatigue_relation_value]
     graph_colums = ['pass_time', fatigue_relation_value, 'fatigue']
+    
+    #ユーザ入力項目
     hours = list(map(lambda x: int(x), input("時間範囲を指定してください(例)12時から15時なら12-15, 1時なら01とする\n").split('-')))
+    rest_flag = trance_boolean(input("「休憩あり」の実験ですか。(例)yes or no\n"))
 
-    result, threshold = create_graph_from_ditection_data_ready(date, hours, csv_colums, jins_meme_data_name=jins_meme_data_name)
+    result, threshold = create_graph_from_ditection_data_ready(date, hours, csv_colums, jins_meme_data_name=jins_meme_data_name, rest_flag=rest_flag)
 
     if not threshold:
         print("疲労度3に達していません。デフォルトの閾値(4)を設定します")
         threshold['fatigue_relation_value'] = os.getenv('BLINK_INTERVAL_THRESHOLD')
         threshold['pass_time'] = os.getenv('THRESHOLD_DEFAULT_PASS_TIME')
-    create_graph_from_ditection_data(date, hours, result, graph_colums, threshold)
+    create_graph_from_ditection_data(date, hours, result, graph_colums, threshold, rest_flag=rest_flag)
 
 """ 疲労度ごとの瞬目の間隔時間平均の振り幅の表作成 """
 def create_blink_interval_time_amplitude_table_flow(date, jins_meme_data_name): 
-    table_minimum_max, table_average = create_blink_interval_time_amplitude_table(date, jins_meme_data_name)
+    rest_flag = trance_boolean(input("「休憩あり」の実験ですか。(例)yes or no\n"))
+    table_minimum_max, table_average = create_blink_interval_time_amplitude_table(date, jins_meme_data_name, rest_flag=rest_flag)
     print(table_minimum_max)
     print(table_average)
+
+
+""" 「休憩あり」かの標準入力をBoolean型に変換する(ついでに入力値の正常チェック) """
+def trance_boolean(str):
+    if str == 'yes':
+        return True
+    elif str == 'no':
+        return False
+    else:
+        print('yesかnoで答えてください。')
+        exit()
 
 #TODO: ドライブ内の特定のファイルのダウンロードオプションとデリートオプションを設ける
 def set_args():

--- a/my_google/my_drive/helper.py
+++ b/my_google/my_drive/helper.py
@@ -21,7 +21,7 @@ def search_file_ready(date, jins_meme_data_name=None, page_limit=100, all_flag=F
 
 """ Google Drive APIでファイルをダウンロードするさいに必要なファイルパスを取得する """
 #TODO:これ、ファイル名をGoogle Driveに保存されているファイル名の時間にしているけど大丈夫かな？ファイル名とファイル内のdateキーの時間と誤差があるため心配
-def get_download_file_path(file, jins_meme_data_name):
+def get_download_file_path(file, jins_meme_data_name, rest_flag=False):
     splited_name = file['name'].split('_')
     date_time = splited_name[0].split('-')
     year = date_time[0][0:4]
@@ -30,8 +30,12 @@ def get_download_file_path(file, jins_meme_data_name):
     hour = date_time[1][0:2]
     minitue = date_time[1][2:4]
     second = date_time[1][4:6]
+    file_path =  f"ditection_data/{year}/{month}/{day}/{hour}/{minitue}-{second}_{jins_meme_data_name}.csv"
+    #「休憩あり」の実験データ用パス
+    if rest_flag:
+        file_path = f"ditection_data/rest/{year}/{month}/{day}/{hour}/{minitue}-{second}_{jins_meme_data_name}.csv"
 
-    return  f"ditection_data/{year}/{month}/{day}/{hour}/{minitue}-{second}_{jins_meme_data_name}.csv"
+    return file_path
 
 """ 開始時刻を取得する """
 def get_start_time(drive, jins_meme_data_name, date_time):


### PR DESCRIPTION
# 「休憩あり」のディレクトリ作成
休憩ありかなしかを考えるべき場所は以下の通り。
- 疲労度保存パス(`fatigue_data/rest`)
- `Jins meme`計測データ保存パス(`ditection_data/rest`)
以上より、データ保存時とローカル保存してあるデータへのアクセス時それぞれの場合変更が必要となる。
ユーザ入力を求め「休憩あり」かどうかの情報は`rest_flag`に持たせ、「休憩あり」の時にファイルパスを変更できるようにした。